### PR TITLE
SDMMC slot width and speed options

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -21,6 +21,43 @@ menu "FTP Server Configuration"
 				Use FAT File System on MMC SDCARD.
 	endchoice
 
+	config SDMMC_ONE_LINE_MODE
+		depends on MMC_SDCARD
+		bool "USE 1-line SD mode"
+		default false
+		help
+			Use only 1-line (true) or 4-lines (false, defalut) SD mode.
+			The 4-lines mode is faster but not all SD slots support it.
+			If you have trouble mounting an SD card, set this parameter to true.
+
+	choice SDMMC_SPEED
+		depends on MMC_SDCARD
+		prompt "SD card MMC speed"
+		default SDMMC_SPEED_HIGH
+		help
+			SD card speed. High values may cause SD card operation to be unstable.
+		config SDMMC_SPEED_52M
+			bool "52 KHz"
+			help
+				Very high speed.
+		config SDMMC_SPEED_26M
+			bool "26 KHz"
+			help
+				Higher speed.
+		config SDMMC_SPEED_HIGH
+			bool "40 KHz"
+			help
+				High speed.
+		config SDMMC_SPEED_DEFAULT
+			bool "20 KHz"
+			help
+				Default speed.
+		config SDMMC_SPEED_PROBING
+			bool "0.4 KHz"
+			help
+				Probing speed.
+	endchoice
+
 	config MISO_GPIO
 		depends on SPI_SDCARD
 		int "MISO GPIO number"


### PR DESCRIPTION
Hello and thanks for the project, I appreciate clean C over bulky Arduinish code.

This pull request brings two additional options to the SD/MMC peripheral and fixes a bug when the static IP option is selected (`ip_info` was undeclared; a typo).

The first SD/MMC option allows the users to select either 1-line or 4-line width slot mode. This is crucial for ESP boards like TTGO T8 where three other data pins of an SD card slot are not connected.

The second SD/MMC option allows the users to select the SD/MMC max frequency to operate on.

The latter option, however, has not influenced the final transmission speed, which remained around only 30 KB/s. At the same time, I've achieved ~300 KB/s speed using https://github.com/fa1ke5/ESP32_FTPServer_SD_MMC project. Don't know why. Maybe you have ideas.

Anyway, I've just decided to put in my two cents in your project.