### PR TITLE
Change server IP address obtaining

### DIFF
--- a/main/ftp.h
+++ b/main/ftp.h
@@ -169,9 +169,8 @@ typedef enum {
 #define ONFIG_MICROPY_FILESYSTEM_TYPE 0
 #define MICROPY_ALLOC_PATH_MAX (512)
 
-#define MAX_ACTIVE_INTERFACES   3
+// #define MAX_ACTIVE_INTERFACES   3
 //tcpip_adapter_if_t tcpip_if[MAX_ACTIVE_INTERFACES] = {TCPIP_ADAPTER_IF_MAX};
-esp_netif_t *net_if[MAX_ACTIVE_INTERFACES];
 
 #define VFS_NATIVE_MOUNT_POINT          "/_#!#_spiffs"
 #define VFS_NATIVE_SDCARD_MOUNT_POINT   "/_#!#_sdcard"


### PR DESCRIPTION
Previous method to obtain server IP is just working when Wi-Fi is enabled and there is no remote connection (Only local IP address is accepted). In this new method, no matters how many interfaces are enabled (Wi-Fi, Ethernet and etc.) and it can be connected through internet or remote.
It has been tested with WinSCP (windows) and FX file manager (android).